### PR TITLE
Bug-Aaron:Fix bug that prevented stories in components folder from running

### DIFF
--- a/Developers/.storybook/main.js
+++ b/Developers/.storybook/main.js
@@ -1,22 +1,23 @@
 /** @type { import('@storybook/nextjs').StorybookConfig } */
 const config = {
   stories: [
-    "../stories/**/*.mdx",
-    "../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)",
-    "../components/**/*.stories.@(js|jsx|mjs|ts|tsx)",
+    '../stories/**/*.mdx',
+    '../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)',
+    '../app/components/**/*.stories.@(js|jsx|mjs|ts|tsx)',
   ],
   addons: [
-    "@storybook/addon-links",
-    "@storybook/addon-essentials",
-    "@storybook/addon-onboarding",
-    "@storybook/addon-interactions",
+    '@storybook/addon-links',
+    '@storybook/addon-essentials',
+    '@storybook/addon-onboarding',
+    '@storybook/addon-interactions',
   ],
   framework: {
-    name: "@storybook/nextjs",
+    name: '@storybook/nextjs',
     options: {},
   },
+  staticDirs: ['../public'],
   docs: {
-    autodocs: "tag",
+    autodocs: 'tag',
   },
-};
-export default config;
+}
+export default config


### PR DESCRIPTION
The initial configuration on line 6 of main.js file in the .stories folder resulted in errors which prevented stories created in the components folder from running. The initial configuration was `../components/**/*.stories.@(js|jsx|mjs|ts|tsx)`
The fix involves pointing to the app directory where the components folder which contains the stories is located. The configuration after the fix is `../app/components/**/*.stories.@(js|jsx|mjs|ts|tsx)`
Line 18 was also added to set `public` folder as static asset folder for stories. The addition is `staticDirs: ['../public'],`